### PR TITLE
Updated the price history client endDate and startDate to be numbers

### DIFF
--- a/src/clients/price-history-client.ts
+++ b/src/clients/price-history-client.ts
@@ -14,8 +14,8 @@ export interface PriceHistoryOptions {
   period?: number;
   frequencyType?: FrequencyType;
   frequency?: number;
-  endDate?: Date;
-  startDate?: Date;
+  endDate?: number;
+  startDate?: number;
   needExtendedHoursData?: boolean;
 }
 

--- a/tests/clients/price-history-client.test.ts
+++ b/tests/clients/price-history-client.test.ts
@@ -18,7 +18,9 @@ describe('Price history client tests', () => {
 
   it('should get price history', async () => {
     const symbol = 'OSTK';
-    const priceHistoryOptions = createMock<PriceHistoryOptions>();
+    const priceHistoryOptions = createMock<PriceHistoryOptions>({
+      periodType: 'day',
+    });
     const expectedResult = createMock<CandleList>({
       candles: [
         {

--- a/tests/clients/price-history-client.test.ts
+++ b/tests/clients/price-history-client.test.ts
@@ -16,11 +16,9 @@ describe('Price history client tests', () => {
     mockedAxios = axios as jest.Mocked<typeof axios>;
   });
 
-  it('should get price history', async () => {
+  it('should get price history - defaults', async () => {
     const symbol = 'OSTK';
-    const priceHistoryOptions = createMock<PriceHistoryOptions>({
-      periodType: 'day',
-    });
+    const priceHistoryOptions = createMock<PriceHistoryOptions>();
     const expectedResult = createMock<CandleList>({
       candles: [
         {
@@ -39,6 +37,66 @@ describe('Price history client tests', () => {
     mockedAxios.get.mockImplementationOnce((url: string) => {
       if (
         url === 'https://api.tdameritrade.com/v1/marketdata/OSTK/pricehistory'
+      ) {
+        return Promise.resolve({
+          data: {
+            candles: [
+              {
+                open: 70.95,
+                high: 71.7,
+                low: 69.1,
+                close: 69.39,
+                volume: 608751,
+                datetime: 1631595600000,
+              },
+            ],
+            symbol: 'OSTK',
+            empty: false,
+          },
+        });
+      } else {
+        return Promise.resolve({ data: `unknown url: ${url}` });
+      }
+    });
+
+    const { data } = await client.priceHistory.getPriceHistory(
+      symbol,
+      priceHistoryOptions
+    );
+
+    expect(data).toEqual(expectedResult);
+  });
+
+  it('should get price history', async () => {
+    const symbol = 'OSTK';
+    const priceHistoryOptions = createMock<PriceHistoryOptions>({
+      periodType: 'day',
+      period: 1,
+      frequencyType: 'minute',
+      frequency: 5,
+      endDate: 1631595600000,
+      startDate: 1631595610000,
+      needExtendedHoursData: true,
+    });
+    const expectedResult = createMock<CandleList>({
+      candles: [
+        {
+          open: 70.95,
+          high: 71.7,
+          low: 69.1,
+          close: 69.39,
+          volume: 608751,
+          datetime: 1631595600000,
+        },
+      ],
+      symbol: 'OSTK',
+      empty: false,
+    });
+
+    mockedAxios.get.mockImplementationOnce((url: string) => {
+      if (
+        url ===
+        'https://api.tdameritrade.com/v1/marketdata/OSTK/pricehistory?periodType=day&period=1&frequencyType=minute&frequency=5&endDate=1631595600000&startDate=1631595610000&needExtendedHoursData=true'
       ) {
         return Promise.resolve({
           data: {

--- a/tests/clients/price-history-client.test.ts
+++ b/tests/clients/price-history-client.test.ts
@@ -17,18 +17,53 @@ describe('Price history client tests', () => {
   });
 
   it('should get price history', async () => {
-    const expectedResult = createMock<CandleList>();
-
-    mockedAxios.get.mockResolvedValueOnce({ data: expectedResult });
-
-    const symbol = 'mySymbol';
+    const symbol = 'OSTK';
     const priceHistoryOptions = createMock<PriceHistoryOptions>();
+    const expectedResult = createMock<CandleList>({
+      candles: [
+        {
+          open: 70.95,
+          high: 71.7,
+          low: 69.1,
+          close: 69.39,
+          volume: 608751,
+          datetime: 1631595600000,
+        },
+      ],
+      symbol: 'OSTK',
+      empty: false,
+    });
+
+    mockedAxios.get.mockImplementationOnce((url: string) => {
+      if (
+        url === 'https://api.tdameritrade.com/v1/marketdata/OSTK/pricehistory'
+      ) {
+        return Promise.resolve({
+          data: {
+            candles: [
+              {
+                open: 70.95,
+                high: 71.7,
+                low: 69.1,
+                close: 69.39,
+                volume: 608751,
+                datetime: 1631595600000,
+              },
+            ],
+            symbol: 'OSTK',
+            empty: false,
+          },
+        });
+      } else {
+        return Promise.resolve({ data: `unknown url: ${url}` });
+      }
+    });
 
     const { data } = await client.priceHistory.getPriceHistory(
       symbol,
       priceHistoryOptions
     );
 
-    expect(data).toBe(expectedResult);
+    expect(data).toEqual(expectedResult);
   });
 });


### PR DESCRIPTION
Updated the price history client endDate and startDate to be numbers instead of Dates per the documentation.

Start date as milliseconds since epoch